### PR TITLE
Add Meeting Copilot ideation documents

### DIFF
--- a/meeting-copilot/meeting-copilot-requirements.md
+++ b/meeting-copilot/meeting-copilot-requirements.md
@@ -1,0 +1,223 @@
+# Meeting Copilot — Detailed Requirements Document
+**Version:** 0.1 (Draft)
+**Date:** 2026-02-14
+**Authors:** Jonathan Gough, Roy Bales (requirements), Clarice (documentation)
+**Status:** Ideation / Scoping
+
+---
+
+## 1. Overview
+
+Meeting Copilot is a local desktop application designed to act as a real-time AI-powered assistant during live conversations — whether virtual meetings (Teams, Zoom, WebEx) or in-person discussions. It captures audio, transcribes speech to text, and continuously feeds the transcript to an LLM reasoning model that returns contextual prompts, questions, notes, and suggestions to the user in real time.
+
+The application also serves as a persistent client intelligence system, maintaining historical meeting notes, client profiles, vendor/product catalogs, and summarized engagement history across multiple interactions.
+
+---
+
+## 2. Target Users
+
+- **V1 Users:** Jonathan Gough and Roy Bales only
+- **Persona:** High-end technology consultants / Field CTOs acting as mid-to-high-level thought leaders in client engagements
+- **Organization type:** Value-added reseller (VAR) covering a broad portfolio of vendors, products, and services
+- **Security model (V1):** Two-user internal tool. No multi-tenancy, no external access. Additional security deferred to later versions.
+
+---
+
+## 3. Platform Requirements
+
+| Requirement | Specification |
+|---|---|
+| **Application type** | Electron desktop app |
+| **Supported OS (V1)** | macOS (primary), Windows and Linux (investigate Electron parity) |
+| **Deployment model** | Fully local — single executable launch, no separate services to manage |
+| **Self-contained** | Electron app must bundle and auto-start all backend components (SQLite, vector DB, local services) on launch. No manual setup. |
+
+### 3.1 Design Principle
+> "If we have too many moving pieces for a V1, it'll be delicate. It'll break. We'll never use it." — Jonathan Gough
+
+The application must start and stop as a single unit. One click to open, one click (or window close) to shut down. No external daemons, no manual database starts, no Docker containers for V1.
+
+---
+
+## 4. Core Functional Requirements
+
+### 4.1 Audio Capture & Speech-to-Text (STT)
+
+| ID | Requirement | Priority |
+|---|---|---|
+| STT-01 | Capture system audio (speakers) and microphone input simultaneously | V1 |
+| STT-02 | Work across meeting platforms (Teams, Zoom, WebEx) without integration — system-level audio capture | V1 |
+| STT-03 | Work during in-person meetings (microphone-only capture) | V1 |
+| STT-04 | Configurable STT endpoint: local model OR external API (cloud or self-hosted) | V1 |
+| STT-05 | STT endpoint specification uses **OpenAI-compatible API format** (supporting Ollama, LiteLLM, vLLM, cloud providers) | V1 |
+| STT-06 | Ability to **pause and resume** speech-to-text capture during a session | V1 |
+| STT-07 | Speaker diarization (identifying who is speaking) | V2 |
+| STT-08 | Native meeting platform integration (joining as a participant/agent) | Future |
+
+### 4.2 Real-Time LLM Analysis
+
+| ID | Requirement | Priority |
+|---|---|---|
+| LLM-01 | Send cumulative transcript to a reasoning LLM at regular intervals (~60 seconds) | V1 |
+| LLM-02 | LLM endpoint is configurable, using **OpenAI-compatible API format** (same flexibility as STT) | V1 |
+| LLM-03 | LLM context includes: current transcript, client profile, vendor/product catalog, historical meeting summaries for this client | V1 |
+| LLM-04 | LLM returns: suggested questions, talking points, contextual notes, relevant observations | V1 |
+| LLM-05 | LLM must **not** re-suggest topics already discussed in the current transcript | V1 |
+| LLM-06 | LLM must account for already-discussed items to inform deeper/follow-up suggestions | V1 |
+| LLM-07 | Maximum **5 suggestions per analysis cycle** (configurable in settings) | V1 |
+| LLM-08 | For first-time clients (no prior context), delay suggestions until ~1 minute of conversation has elapsed | V1 |
+| LLM-09 | Meeting type (if selected) influences the LLM's prompt strategy and suggestion style | V1 |
+| LLM-10 | Conversation pattern detection and behavioral analysis | V2 |
+| LLM-11 | External/internet research to augment real-time suggestions | Future |
+
+### 4.3 User Interface
+
+| ID | Requirement | Priority |
+|---|---|---|
+| UI-01 | **Split-pane layout:** Running notes/transcript on the left, AI suggestions/prompts on the right | V1 |
+| UI-02 | **Overlay or sidebar mode** — usable alongside meeting applications without dominating screen | V1 |
+| UI-03 | Each suggestion has: **✓ (acknowledge/asked)** and **✗ (dismiss/irrelevant)** actions | V1 |
+| UI-04 | Dismissed items are categorized as positive (already covered) or negative (not relevant) | V1 |
+| UI-05 | Suggestions auto-scroll upward as new ones arrive; silent notifications only | V1 |
+| UI-06 | Optional toggle to view live transcript | V1 |
+| UI-07 | Optional dropdown to select **meeting type** (client call, internal sync, discovery, etc.) — not mandatory | V1 |
+| UI-08 | Settings panel for: STT endpoint, LLM endpoint, max suggestions per cycle, other preferences | V1 |
+
+### 4.4 Client & Vendor Knowledge Base
+
+| ID | Requirement | Priority |
+|---|---|---|
+| KB-01 | **Client profiles** with: name, known technology stack, engagement history, summarized notes from all prior meetings | V1 |
+| KB-02 | **Vendor/product/services catalog** — pre-populated list of what the organization sells and partners with | V1 |
+| KB-03 | Client stack list populated from historical meeting notes (organic updates) | V1 |
+| KB-04 | Client stack includes both products they have AND products they don't have (for cross-sell/gap analysis) | V1 |
+| KB-05 | Users can **manually view, edit, and update** client attributes outside of meetings | V1 |
+| KB-06 | All organic updates from meeting notes are **human-in-the-loop** — flagged for user approval before persisting to client record | V1 |
+| KB-07 | When new meeting contradicts earlier meeting data, flag as **discrepancy** in current meeting notes. Let user decide what goes into summary record. **Never modify earlier meeting notes.** | V1 |
+
+### 4.5 Auto-Prep Mode
+
+| ID | Requirement | Priority |
+|---|---|---|
+| PREP-01 | When a meeting is started with a known client selected, auto-load their profile, historical context, and relevant vendor overlap | V1 |
+| PREP-02 | Present a pre-meeting briefing summary before recording begins | V1 |
+
+### 4.6 Post-Meeting Artifacts
+
+| ID | Requirement | Priority |
+|---|---|---|
+| POST-01 | **Full text transcript** saved as an output artifact | V1 |
+| POST-02 | **Meeting summary** — formatted, structured notes suitable for copy/paste into email | V1 |
+| POST-03 | **Action items** — extracted from the conversation | V1 |
+| POST-04 | **Internal record update** — suggested updates to client profile and notes (human-in-the-loop approval) | V1 |
+| POST-05 | Post-meeting actions are **driven by meeting type** (if selected). Client meetings get full artifact generation by default. | V1 |
+| POST-06 | No automated email sending. Provide formatted text for manual copy/paste. | V1 |
+| POST-07 | Export to email client | Future |
+
+---
+
+## 5. Data Storage Requirements
+
+### 5.1 Storage Architecture
+
+| ID | Requirement | Priority |
+|---|---|---|
+| DATA-01 | **SQLite** for structured data (client profiles, meeting metadata, vendor catalog, action items) — embedded in Electron, no external DB | V1 |
+| DATA-02 | **Vector database** (embedded, e.g., LanceDB or similar) for semantic search over meeting notes and transcripts — auto-starts with app | V1 |
+| DATA-03 | **Flat file storage** — transcripts and meeting notes also saved as plain markdown files for portability and backup | V1 |
+| DATA-04 | Dual storage: structured/searchable in-app AND flat files on disk | V1 |
+| DATA-05 | All data stored locally on user's machine | V1 |
+
+### 5.2 Update & Sync
+
+| ID | Requirement | Priority |
+|---|---|---|
+| SYNC-01 | App should auto-update but with **human-in-the-loop** approval before applying updates | V1 |
+
+---
+
+## 6. Configuration & Settings
+
+| Setting | Details |
+|---|---|
+| STT Endpoint | URL + API key, OpenAI-compatible format |
+| LLM Endpoint | URL + API key + model name, OpenAI-compatible format |
+| Max suggestions per cycle | Default: 5, adjustable |
+| Meeting types | Configurable list (client call, internal, discovery, etc.) |
+| Default post-meeting actions per type | Configurable |
+| Transcript storage location | Local path |
+
+---
+
+## 7. Non-Functional Requirements
+
+| Requirement | Detail |
+|---|---|
+| **Simplicity** | Single-app experience. No multi-service orchestration for V1. |
+| **Resilience** | If LLM or STT endpoint is unreachable, app continues capturing audio and degrades gracefully |
+| **Performance** | UI must remain responsive during STT + LLM processing cycles |
+| **Privacy** | All data local. No telemetry. No cloud sync in V1. |
+| **Portability** | Flat file exports ensure data isn't locked in proprietary formats |
+
+---
+
+## 8. Explicitly Out of Scope (V1)
+
+- Multi-user / multi-tenant support
+- Cloud deployment or hosted version
+- External internet research during meetings
+- Speaker diarization
+- Automated email sending
+- Conversation pattern detection
+- Native meeting platform integrations (Teams bot, Zoom app, etc.)
+- Advanced security/auth (SSO, encryption at rest, etc.)
+
+---
+
+## 9. Complexity Assessment
+
+### 🟢 Easy Button — Achievable with standard tooling
+- Electron app shell with SQLite (better-sqlite3)
+- Settings UI for endpoint configuration
+- OpenAI-compatible API calls for STT and LLM
+- Split-pane UI with suggestion cards
+- Flat file transcript export
+- Post-meeting summary generation
+
+### 🟡 Not-So-Easy — Requires careful implementation
+- System audio + microphone capture cross-platform (macOS vs Windows audio APIs differ significantly)
+- Embedded vector DB with semantic search (LanceDB or Chroma embedded)
+- Real-time streaming transcript → periodic LLM analysis loop
+- Context window management (cumulative transcripts can exceed token limits)
+- Discrepancy detection against historical notes
+
+### 🔴 Hard — Significant engineering effort
+- Overlay/sidebar mode that works alongside any app without focus-stealing
+- Cross-platform audio capture parity (macOS screen recording permissions, Windows WASAPI, Linux PulseAudio)
+- Intelligent deduplication of suggestions across analysis cycles
+- Auto-prep mode with semantic retrieval across all historical meetings for a client
+
+### ⛰️ Insurmountable Hill (for V1 — defer)
+- Real-time speaker diarization without meeting platform integration
+- Native meeting platform agent/bot integration
+- Fully local LLM inference with reasoning-model quality (hardware-dependent)
+
+---
+
+## 10. Recommended Tech Stack (V1)
+
+| Component | Recommendation |
+|---|---|
+| **App shell** | Electron (cross-platform, bundles everything) |
+| **Frontend** | React or Svelte (within Electron renderer) |
+| **Structured DB** | better-sqlite3 (embedded, zero-config) |
+| **Vector DB** | LanceDB (embedded, runs in-process, no server) |
+| **Audio capture** | Node.js native modules + platform audio APIs (BlackHole/loopback on macOS, WASAPI on Windows) |
+| **STT** | OpenAI Whisper API format — configurable endpoint |
+| **LLM** | OpenAI Chat Completions API format — configurable endpoint |
+| **File storage** | Local filesystem, markdown format |
+| **Auto-update** | electron-updater with confirmation dialog |
+
+---
+
+*Document generated from ideation session on 2026-02-14. See full transcript: `transcripts/2026-02-14-meeting-copilot-ideation.md`*

--- a/meeting-copilot/meeting-copilot-summary.md
+++ b/meeting-copilot/meeting-copilot-summary.md
@@ -1,0 +1,116 @@
+# Meeting Copilot — Application Summary
+**Version:** 0.1 (Draft)
+**Date:** 2026-02-14
+
+---
+
+## What Is It?
+
+Meeting Copilot is a **local desktop application** that listens to your meetings in real time — virtual or in-person — and acts as a silent strategic advisor. It transcribes the conversation, feeds it to an AI reasoning model along with client history and your product catalog, and surfaces smart questions, talking points, and contextual notes while you're still on the call.
+
+After the meeting, it generates a full transcript, structured summary, action items, and suggested updates to your client records — all without sending a single thing to the cloud that you don't explicitly configure.
+
+---
+
+## Who Is It For?
+
+Roy Bales and Jonathan Gough — technology consultants and Field CTOs at a value-added reseller. Two users. No one else. V1 is a personal power tool.
+
+---
+
+## Feature Summary
+
+### 🎙️ Audio Capture & Transcription
+- Captures **system audio + microphone** simultaneously (covers both sides of a virtual meeting)
+- Works for **in-person meetings** via microphone only
+- Real-time **speech-to-text** via configurable endpoint (local Whisper, cloud API, self-hosted — anything OpenAI-compatible)
+- **Pause/resume** recording mid-session
+- Full **transcript saved** as a meeting artifact
+
+### 🧠 Real-Time AI Copilot
+- Transcript sent to a **reasoning LLM every ~60 seconds**
+- LLM is aware of: who the client is, what they use, what you sell, what's been discussed before, and what's been said so far today
+- Returns up to **5 suggestions per cycle** (configurable): questions to ask, points to raise, things to note
+- **Never repeats** what's already been discussed
+- **Waits ~1 minute** before suggesting anything on first-time client calls (needs context before it can help)
+- Configurable LLM endpoint — **OpenAI-compatible format** (Ollama, LiteLLM, vLLM, any cloud provider)
+
+### 📋 Live UI
+- **Split-pane layout:** notes on the left, AI suggestions on the right
+- **Overlay/sidebar mode** — sits alongside Teams/Zoom without stealing focus
+- Each suggestion can be:
+  - ✓ **Acknowledged** (asked it / already covered)
+  - ✗ **Dismissed** (not relevant)
+- Suggestions **auto-scroll** upward; notifications are **silent**
+- Optional **live transcript view** toggle
+- Optional **meeting type** dropdown (client call, internal sync, discovery, etc.)
+
+### 👥 Client Intelligence
+- **Client profiles** with technology stack, engagement history, and summarized meeting notes
+- **Vendor/product catalog** — your full portfolio, pre-loaded
+- Client data **updated organically** from meeting notes with **human-in-the-loop** approval
+- **Manual editing** of client profiles outside of meetings
+- **Discrepancy handling:** if new info contradicts old notes, it's flagged — user decides what's canonical. Historical notes are **never modified**.
+
+### 📑 Post-Meeting Artifacts
+- **Full text transcript** (markdown)
+- **Structured meeting summary** — formatted for email copy/paste
+- **Action items** — extracted from conversation
+- **Client record update suggestions** — proposed changes to client profile, requiring approval
+- Artifact generation **driven by meeting type** — client meetings get the full treatment by default
+
+### 🚀 Auto-Prep Mode
+- Select a client before starting → app loads their **profile, history, and vendor overlap**
+- Get a **pre-meeting briefing** before you hit record
+
+### 💾 Data & Storage
+- **All local** — nothing leaves your machine unless you point it at an external API
+- **SQLite** for structured data (embedded, zero-config)
+- **LanceDB** (or similar) for semantic search across meeting history
+- **Flat markdown files** for transcripts and notes (portable, backup-friendly)
+- **Dual storage** — searchable in-app AND human-readable on disk
+
+### ⚙️ Configuration
+- STT endpoint (URL, API key)
+- LLM endpoint (URL, API key, model)
+- Max suggestions per cycle (default: 5)
+- Meeting type definitions
+- Post-meeting action defaults per meeting type
+- Transcript storage path
+
+---
+
+## What It Does NOT Do (V1)
+
+| Not in V1 | Why |
+|---|---|
+| Speaker diarization | Requires meeting platform integration or advanced local models |
+| Send emails | Provides formatted text; user copy/pastes |
+| Internet research during calls | Scope creep; deferred |
+| Multi-user support | Two users only for now |
+| Cloud sync | Local-only by design |
+| Conversation pattern analysis | V2 feature |
+| Auto-modify historical notes | Immutable meeting records by policy |
+
+---
+
+## Complexity at a Glance
+
+| Difficulty | What's Involved |
+|---|---|
+| 🟢 **Straightforward** | Electron app, SQLite, settings UI, API calls, split-pane layout, post-meeting artifacts |
+| 🟡 **Takes work** | Cross-platform audio capture, embedded vector search, context window management, LLM deduplication logic |
+| 🔴 **Hard** | Always-on-top overlay without focus steal, audio capture permission handling per OS, intelligent prep mode |
+| ⛰️ **Not V1** | Diarization, native meeting bots, fully local reasoning-quality LLM |
+
+---
+
+## One-Line Pitch
+
+> A private, local AI copilot that listens to your meetings, knows your clients, and whispers the right questions in your ear — then writes up the notes when you're done.
+
+---
+
+*See also:*
+- *Full requirements: `meeting-copilot-requirements.md`*
+- *Ideation transcript: `transcripts/2026-02-14-meeting-copilot-ideation.md`*

--- a/meeting-copilot/transcripts/2026-02-14-meeting-copilot-ideation.md
+++ b/meeting-copilot/transcripts/2026-02-14-meeting-copilot-ideation.md
@@ -1,0 +1,128 @@
+# Meeting Copilot — Ideation Session Transcript
+**Date:** 2026-02-14
+**Participants:** Jonathan Gough, Roy Bales, Clarice (AI)
+**Channel:** Clarice's Hangout (Telegram)
+
+---
+
+**Jonathan Gough:**
+I have an idea for an application that I would like you to help Roy and I flush out. We're not building anything yet. Your job is to ask us questions about the application. How it would work? Think about functionality that we would need functionality that we would not need. That way we can fully scope out if we want to do this and how we would do it. So the idea is application for a computer. I'm thinking if it's a Mac and electron app, I'm not sure what the equivalent would be for a PC or Linux. Is there an equivalent? We want the app to record speech to text. We want to turn the app on during a conversation, for example, a Microsoft teams meeting a WebEx, a zoom meeting and record the audio. It would then turn that into text. We would need to find a way in parallel be sending the transcript of the full conversation every every minute or so to an llm and have that llm a reasoning model. I'm thinking be considering the context of the call itself. It would be considering the client that is on the call. It will be considering what we as an organization can offer them with the purpose of returning to the user ideas, questions, bullet point notes in real time. For example, Roy and I are talking to Delta airlines about AI ops project running on IBM I series looking for anomalies. This app would be prompting us with questions to ask about how the hardware is managed. What software is being run? Have they considered XYZ? It would not bring back things that had already been brought up. However, it would take those things into account potentially go out to the internet and gain context about details that are being discussed. Bring them back and provide those as notes, point of reference and also potentially put those into a question. Keep this as an idea. Ask Roy and I no less than 10 clarifying questions. Not all at once but one by one.
+
+---
+
+**Jonathan Gough:**
+The first iteration would be for Roy and I. The persona is a high-end consultant speaking to clients a mid to high level thought leader within within an organization talking to peers.
+
+---
+
+**Roy Bales:**
+In a perfect world it would be part of the meeting (most of which are teams based) as an agent etc and be able to align who is speaking context, but being able to capture both speakers and microphone would be needed for our MVP even if it doesn't know who is speaking.
+
+---
+
+**Jonathan Gough:**
+Collecting all meeting audio and doing speech to text is a great first start. Diarization would be an upgrade.
+
+---
+
+**Roy Bales:**
+Overlay or sidebar would be my preference, ideally I could use it during an in-person meeting as well.
+
+---
+
+**Jonathan Gough:**
+I'm thinking the app would have running notes on the left hand side and on the right hand side it would have questions and prompts that would show up. It would have the ability to X out something that you wouldn't want to ask. A checkbox to say that you know it already or to acknowledge that you asked the question or got an answer to that question inadvertently. The idea being that you would be able to clear the screen of things you didn't want in your view while designating them as positive or negative. I think there would be an option to see the transcript live if you wanted to.
+
+---
+
+**Jonathan Gough:**
+We would have a pre-populated list of vendors, products and services. We would also have a list of clients and a history of summarized notes in the database. This would be like a front end to our notes on all of our opportunities and all of our meetings and everything that we're doing. That way, if we're having the second call the third call the fourth call. We have a summarized context of what their current stack is, what the expectations are, etc.
+
+---
+
+**Jonathan Gough:**
+Yes, we would have a list based on the conversations and what we know of their current internal stack for the client. That list is going to be populated based on our historical notes. Pre-populated list of vendors will likely include things they already have in house. In addition to things that they do not have. We are a value-added reseller and sell almost everything. Therefore, there will be overlap and there will be mismatches. This scope at this point does not include external research.
+
+---
+
+**Jonathan Gough:**
+Yes, I think an optional drop down for a meeting type is a welcome addition. It is not mandatory. The model would be able to intuit based on the conversation what's happening. If it's the first of its kind, like there's no context, we might want to wait until the conversation has elapsed for a minute or so before trying to provide suggestions. Quick question for you. How many more questions do we have? These are all great questions.
+
+---
+
+**Jonathan Gough:**
+Once again, great question. Based on the meeting type that would be selected if selected, a set of after meeting actions would take place by default. If it's a client meeting, it would create artifacts for our records. It would update internal notes. It would create action items and it would create a stock set of meeting summary notes that we could send out as an email. It would not send any emails however. It would simply provide formatted texts that could be copy pasted. Maybe one day exported to an email client.
+
+---
+
+**Roy Bales:**
+I'm a fan of middle ground, trust but verify.
+
+---
+
+**Roy Bales:**
+Internal tool only for now, only Jonathan and I will use/have access and we can add extra security later.
+
+---
+
+**Jonathan Gough:**
+This is going to be a local app to start with. We want this tight individual closed loop. V1 is going to help us understand better what it is that we need want and how well this will work. That being said, we would like you to ask us questions to better flush out the architecture. Or actually we would like you to offer us suggestions on how we would architect this for a local deployment only. What do we need to think about? How complex would it get? What's the easy button? Not so easy button and the super hard button and the insurmountable Hill.
+
+---
+
+**Jonathan Gough:**
+I have a clarifying question. When I clicked open the application an electron application, will that automatically start up the vector DB? The sqlite DB is using electron. Is that going to manage the back end part of this for me or am I going to have to set that up on my own? I want to make this simple, less headache to start stop etc. if we have too many moving pieces for a V1, it'll be delicate. It'll break. We'll never use it. Help me understand the practical side of using it. That will inform how I think about it.
+
+---
+
+**Jonathan Gough:**
+We want to run the speech to text either locally or pointing at an external endpoint. That endpoint may be a cloud API or we would specify a specific API endpoint that we are self-hosting. Notifications need to be silent. If a lot of things come back and pop up on the screen they need to auto scroll up. That's the purpose of having a check mark or an x to clear things out. Which reminds me we may need to limit the number of things that come back all at once.
+
+---
+
+**Jonathan Gough:**
+I think a max of five per cycle is appropriate. I think there should be a setting where we can change it. I think being able to pause speech to text is also a v1 feature. We should also be recording and capturing the full text transcript as one of the output artifacts.
+
+---
+
+**Roy Bales:**
+Let's add patterns to v2.
+
+---
+
+**Jonathan Gough:**
+For V1 let's say it is configurable. The specification would be using the standard OpenAI format. That would allow us to use Ollama, LiteLLM, vLLM, or any other OpenAI API in a cloud or neocloud.
+
+---
+
+**Roy Bales:**
+Can we do a combination, store them flat as well as in a format that can be searchable within the app? App should auto update but with human in the loop.
+
+---
+
+**Jonathan Gough:**
+It should be captured in the notes for current meeting as a correction. It should be flagged as a discrepancy and let the user decide what goes in the summary record. Don't touch the earlier meeting notes.
+
+---
+
+**Jonathan Gough:**
+I like the auto prep mode approach.
+
+---
+
+**Jonathan Gough:**
+Yes, we can view and edit and update client attributes. I want all of that to be updated organically from meeting notes, however we should have the option to add to it in case we get info not in a meeting.
+
+---
+
+**Roy Bales:**
+You've asked FAR more than 10 questions.
+
+---
+
+**Jonathan Gough:**
+Write this up as 1. a detailed requirements document 2. An application summary of features and functionality 3. create a new directory for transcripts and put the entire transcript of this conversation in it as a md file.
+
+---
+
+*End of transcript.*


### PR DESCRIPTION
## Meeting Copilot — Ideation Session (2026-02-14)

This PR adds the initial scoping documents from the Meeting Copilot ideation session between Jonathan, Roy, and Clarice.

### Files Added

```
meeting-copilot/
├── meeting-copilot-requirements.md          # Detailed requirements document (V1/V2 scope)
├── meeting-copilot-summary.md               # Application summary of features & functionality
└── transcripts/
    └── 2026-02-14-meeting-copilot-ideation.md  # Full ideation session transcript
```

### What's in the requirements doc?
- Platform requirements (Electron, local-only, single-app experience)
- Audio capture & STT requirements (OpenAI-compatible API)
- Real-time LLM analysis specs (context-aware suggestions, configurable endpoints)
- UI layout (split-pane, overlay/sidebar, suggestion triage)
- Client & vendor knowledge base
- Auto-prep mode
- Post-meeting artifact generation
- Data storage architecture (SQLite + LanceDB + flat markdown)
- Complexity assessment (easy → insurmountable)
- Recommended tech stack

### Status
Ideation only — no code yet. This captures the full scope discussion for reference as we decide next steps.